### PR TITLE
Feat: verify file

### DIFF
--- a/shared/packages/api/src/expectationApi.ts
+++ b/shared/packages/api/src/expectationApi.ts
@@ -21,12 +21,14 @@ export namespace Expectation {
 		| QuantelClipThumbnail
 		| QuantelClipPreview
 		| JsonDataCopy
+		| FileVerify
 
 	/** Defines the Expectation type, used to separate the different Expectations */
 	export enum Type {
 		FILE_COPY = 'file_copy',
 		MEDIA_FILE_THUMBNAIL = 'media_file_thumbnail',
 		MEDIA_FILE_PREVIEW = 'media_file_preview',
+		FILE_VERIFY = 'file_verify',
 
 		PACKAGE_SCAN = 'package_scan',
 		PACKAGE_DEEP_SCAN = 'package_deep_scan',
@@ -266,6 +268,16 @@ export namespace Expectation {
 			version: Version.ExpectedFileOnDisk // maybe something else?
 		}
 		workOptions: WorkOptions.RemoveDelay & WorkOptions.UseTemporaryFilePath
+	}
+
+	/** Defines a "Verify File". Doesn't really do any work, just checks that the File exists at the Target. */
+	export interface FileVerify extends Base {
+		type: Type.FILE_VERIFY
+
+		startRequirement: {
+			sources: []
+		}
+		endRequirement: FileCopy['endRequirement']
 	}
 
 	/** Contains definitions of specific PackageContainer types, used in the Expectation-definitions */

--- a/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/fileCopy.ts
+++ b/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/fileCopy.ts
@@ -205,7 +205,7 @@ export const FileCopy: ExpectationWindowsHandler = {
 			if (!isLocalFolderAccessorHandle(sourceHandle) && !isFileShareAccessorHandle(sourceHandle))
 				throw new Error(`Source AccessHandler type is wrong`)
 			if (!isLocalFolderAccessorHandle(targetHandle) && !isFileShareAccessorHandle(targetHandle))
-				throw new Error(`Source AccessHandler type is wrong`)
+				throw new Error(`Target AccessHandler type is wrong`)
 
 			if (sourceHandle.fullPath === targetHandle.fullPath) {
 				throw new Error('Unable to copy: Source and Target file paths are the same!')
@@ -278,7 +278,7 @@ export const FileCopy: ExpectationWindowsHandler = {
 				!isFileShareAccessorHandle(targetHandle) &&
 				!isHTTPProxyAccessorHandle(targetHandle)
 			)
-				throw new Error(`Source AccessHandler type is wrong`)
+				throw new Error(`Target AccessHandler type is wrong`)
 
 			let wasCancelled = false
 			let sourceStream: PackageReadStream | undefined = undefined
@@ -352,7 +352,7 @@ export const FileCopy: ExpectationWindowsHandler = {
 			compareResourceIds(lookupSource.accessor.networkId, lookupTarget.accessor.networkId)
 		) {
 			if (!isQuantelClipAccessorHandle(sourceHandle)) throw new Error(`Source AccessHandler type is wrong`)
-			if (!isFileShareAccessorHandle(targetHandle)) throw new Error(`Source AccessHandler type is wrong`)
+			if (!isFileShareAccessorHandle(targetHandle)) throw new Error(`Target AccessHandler type is wrong`)
 			if (!sourceHandle.fileflowURL) throw new Error(`Source AccessHandler does not have a Fileflow URL set`)
 
 			targetHandle.disableDriveMapping = true // FileFlow needs to use the network share, not the mapped network drive

--- a/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/fileVerify.ts
+++ b/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/fileVerify.ts
@@ -1,0 +1,168 @@
+import { GenericWorker } from '../../../worker'
+import { UniversalVersion, getStandardCost, compareActualExpectVersions } from '../lib/lib'
+import { ExpectationWindowsHandler } from './expectationWindowsHandler'
+import {
+	Accessor,
+	Expectation,
+	hashObj,
+	ReturnTypeDoYouSupportExpectation,
+	ReturnTypeGetCostFortExpectation,
+	ReturnTypeIsExpectationFullfilled,
+	ReturnTypeIsExpectationReadyToStartWorkingOn,
+	ReturnTypeRemoveExpectation,
+} from '@shared/api'
+import {
+	isFileShareAccessorHandle,
+	isHTTPProxyAccessorHandle,
+	isLocalFolderAccessorHandle,
+} from '../../../accessorHandlers/accessor'
+import { IWorkInProgress, WorkInProgress } from '../../../lib/workInProgress'
+import { checkWorkerHasAccessToPackageContainersOnPackage, lookupAccessorHandles, LookupPackageContainer } from './lib'
+
+/**
+ * Verifies that a file exists on the target. Doesn't actually perform any work, just verifies that the file exists on the target,
+ */
+export const FileVerify: ExpectationWindowsHandler = {
+	doYouSupportExpectation(exp: Expectation.Any, genericWorker: GenericWorker): ReturnTypeDoYouSupportExpectation {
+		return checkWorkerHasAccessToPackageContainersOnPackage(genericWorker, {
+			sources: undefined,
+			targets: exp.endRequirement.targets,
+		})
+	},
+	getCostForExpectation: async (
+		exp: Expectation.Any,
+		worker: GenericWorker
+	): Promise<ReturnTypeGetCostFortExpectation> => {
+		if (!isFileVerify(exp)) throw new Error(`Wrong exp.type: "${exp.type}"`)
+		return getStandardCost(exp, worker)
+	},
+	isExpectationReadyToStartWorkingOn: async (
+		exp: Expectation.Any,
+		worker: GenericWorker
+	): Promise<ReturnTypeIsExpectationReadyToStartWorkingOn> => {
+		if (!isFileVerify(exp)) throw new Error(`Wrong exp.type: "${exp.type}"`)
+
+		const lookupTarget = await lookupTargets(worker, exp)
+		if (!lookupTarget.ready) return { ready: lookupTarget.ready, reason: lookupTarget.reason }
+
+		return {
+			ready: true,
+		}
+	},
+	isExpectationFullfilled: async (
+		exp: Expectation.Any,
+		_wasFullfilled: boolean,
+		worker: GenericWorker
+	): Promise<ReturnTypeIsExpectationFullfilled> => {
+		if (!isFileVerify(exp)) throw new Error(`Wrong exp.type: "${exp.type}"`)
+
+		const lookupTarget = await lookupTargets(worker, exp)
+		if (!lookupTarget.ready)
+			return {
+				fulfilled: false,
+				reason: {
+					user: `Not able to access target, due to: ${lookupTarget.reason.user} `,
+					tech: `Not able to access target: ${lookupTarget.reason.tech}`,
+				},
+			}
+
+		const issuePackage = await lookupTarget.handle.checkPackageReadAccess()
+		if (!issuePackage.success) {
+			return {
+				fulfilled: false,
+				reason: {
+					user: `Target package: ${issuePackage.reason.user}`,
+					tech: `Target package: ${issuePackage.reason.tech}`,
+				},
+			}
+		}
+
+		// Check that the version of the target file is correct:
+		const actualTargetVersion = await lookupTarget.handle.getPackageActualVersion()
+
+		const compareVersionResult = compareActualExpectVersions(actualTargetVersion, exp.endRequirement.version)
+		if (!compareVersionResult.success) {
+			return {
+				fulfilled: false,
+				reason: {
+					user: `Target version is wrong: ${compareVersionResult.reason.user}`,
+					tech: `${compareVersionResult.reason.tech}`,
+				},
+			}
+		}
+
+		return {
+			fulfilled: true,
+		}
+	},
+	workOnExpectation: async (exp: Expectation.Any, worker: GenericWorker): Promise<IWorkInProgress> => {
+		if (!isFileVerify(exp)) throw new Error(`Wrong exp.type: "${exp.type}"`)
+
+		// Since we only verify the existence of the file (in isExpectationFullfilled), we don't need to do anything here.
+
+		const lookupTarget = await lookupTargets(worker, exp)
+		if (!lookupTarget.ready) throw new Error(`Can't start working due to target: ${lookupTarget.reason.tech}`)
+
+		const targetHandle = lookupTarget.handle
+		if (
+			lookupTarget.accessor.type === Accessor.AccessType.LOCAL_FOLDER ||
+			lookupTarget.accessor.type === Accessor.AccessType.FILE_SHARE ||
+			lookupTarget.accessor.type === Accessor.AccessType.HTTP_PROXY
+		) {
+			if (
+				!isLocalFolderAccessorHandle(targetHandle) &&
+				!isFileShareAccessorHandle(targetHandle) &&
+				!isHTTPProxyAccessorHandle(targetHandle)
+			)
+				throw new Error(`Target AccessHandler type is wrong`)
+
+			const workInProgress = new WorkInProgress({ workLabel: 'Verifying file' }, async () => {
+				// on cancel, doing nothing
+			}).do(async () => {
+				// done
+				const actualTargetVersion = await lookupTarget.handle.getPackageActualVersion()
+				const actualSourceVersionHash = hashObj(actualTargetVersion)
+
+				workInProgress._reportComplete(
+					actualSourceVersionHash,
+					{
+						user: `Verification done`,
+						tech: `Completed`,
+					},
+					undefined
+				)
+			})
+
+			return workInProgress
+		} else {
+			throw new Error(`FileVerify.workOnExpectation: Unsupported accessor target "${lookupTarget.accessor.type}"`)
+		}
+	},
+	removeExpectation: async (exp: Expectation.Any, _worker: GenericWorker): Promise<ReturnTypeRemoveExpectation> => {
+		if (!isFileVerify(exp)) throw new Error(`Wrong exp.type: "${exp.type}"`)
+		// Don't do anything upon removal.
+
+		return {
+			removed: true,
+		}
+	},
+}
+function isFileVerify(exp: Expectation.Any): exp is Expectation.FileVerify {
+	return exp.type === Expectation.Type.FILE_VERIFY
+}
+
+function lookupTargets(
+	worker: GenericWorker,
+	exp: Expectation.FileVerify
+): Promise<LookupPackageContainer<UniversalVersion>> {
+	return lookupAccessorHandles<UniversalVersion>(
+		worker,
+		exp.endRequirement.targets,
+		exp.endRequirement.content,
+		exp.workOptions,
+		{
+			read: true,
+			readPackage: true,
+		}
+	)
+}

--- a/shared/packages/worker/src/worker/workers/windowsWorker/lib/lib.ts
+++ b/shared/packages/worker/src/worker/workers/windowsWorker/lib/lib.ts
@@ -146,10 +146,16 @@ export function findBestAccessorOnPackageContainer(
 }
 /** Return a standard cost for the various accessorHandler types */
 export function getStandardCost(exp: Expectation.Any, worker: GenericWorker): number {
-	const source = findBestPackageContainerWithAccessToPackage(worker, exp.startRequirement.sources)
-	const target = findBestPackageContainerWithAccessToPackage(worker, exp.endRequirement.targets)
+	let sourceCost: number = Number.POSITIVE_INFINITY
+	if (exp.startRequirement.sources.length > 0) {
+		const source = findBestPackageContainerWithAccessToPackage(worker, exp.startRequirement.sources)
+		sourceCost = source ? getAccessorCost(source.accessor.type) : Number.POSITIVE_INFINITY
+	} else {
+		// If there are no sources defined, there is no cost for the source
+		sourceCost = 0
+	}
 
-	const sourceCost = source ? getAccessorCost(source.accessor.type) : Number.POSITIVE_INFINITY
+	const target = findBestPackageContainerWithAccessToPackage(worker, exp.endRequirement.targets)
 	const targetCost = target ? getAccessorCost(target.accessor.type) : Number.POSITIVE_INFINITY
 
 	return 30 * (sourceCost + targetCost)

--- a/shared/packages/worker/src/worker/workers/windowsWorker/windowsWorker.ts
+++ b/shared/packages/worker/src/worker/workers/windowsWorker/windowsWorker.ts
@@ -29,6 +29,7 @@ import { QuantelThumbnail } from './expectationHandlers/quantelClipThumbnail'
 import { testFFMpeg, testFFProbe } from './expectationHandlers/lib/ffmpeg'
 import { JsonDataCopy } from './expectationHandlers/jsonDataCopy'
 import { SetupPackageContainerMonitorsResult } from '../../accessorHandlers/genericHandle'
+import { FileVerify } from './expectationHandlers/fileVerify'
 
 /** This is a type of worker that runs on a windows machine */
 export class WindowsWorker extends GenericWorker {
@@ -92,6 +93,8 @@ export class WindowsWorker extends GenericWorker {
 		switch (exp.type) {
 			case Expectation.Type.FILE_COPY:
 				return FileCopy
+			case Expectation.Type.FILE_VERIFY:
+				return FileVerify
 			case Expectation.Type.PACKAGE_SCAN:
 				return PackageScan
 			case Expectation.Type.PACKAGE_DEEP_SCAN:


### PR DESCRIPTION
This PR Adds the expectationHandler "fileVerify", used to just verify that a file exists,

This is useful when copying a file into a folder is handled manually, and we just want to verify that the file exists in that folder.