### PR TITLE
fix: allow deep scanning of audio-only files

### DIFF
--- a/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/lib/scan.ts
+++ b/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/lib/scan.ts
@@ -16,8 +16,14 @@ import { FileShareAccessorHandle } from '../../../../accessorHandlers/fileShare'
 import { HTTPProxyAccessorHandle } from '../../../../accessorHandlers/httpProxy'
 import { HTTPAccessorHandle } from '../../../../accessorHandlers/http'
 
-interface FFProbeScanResult {
+export interface FFProbeScanResultStream {
+	index: number
+	codec_type: string
+}
+
+export interface FFProbeScanResult {
 	// to be defined...
+	streams?: FFProbeScanResultStream[]
 	format?: {
 		duration: number
 	}

--- a/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/packageDeepScan.ts
+++ b/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/packageDeepScan.ts
@@ -22,9 +22,9 @@ import {
 } from '../../../accessorHandlers/accessor'
 import { IWorkInProgress, WorkInProgress } from '../../../lib/workInProgress'
 import { checkWorkerHasAccessToPackageContainersOnPackage, lookupAccessorHandles, LookupPackageContainer } from './lib'
-import { DeepScanResult } from './lib/coreApi'
+import { DeepScanResult, FieldOrder, ScanAnomaly } from './lib/coreApi'
 import { CancelablePromise } from '../../../lib/cancelablePromise'
-import { scanFieldOrder, scanMoreInfo, scanWithFFProbe } from './lib/scan'
+import { FFProbeScanResult, scanFieldOrder, scanMoreInfo, scanWithFFProbe } from './lib/scan'
 import { WindowsWorker } from '../windowsWorker'
 
 /**
@@ -172,23 +172,36 @@ export const PackageDeepScan: ExpectationWindowsHandler = {
 
 				// Scan with FFProbe:
 				currentProcess = scanWithFFProbe(sourceHandle)
-				const ffProbeScan = await currentProcess
+				const ffProbeScan: FFProbeScanResult = await currentProcess
+				const hasVideoStream =
+					ffProbeScan.streams && ffProbeScan.streams.some((stream) => stream.codec_type === 'video')
 				workInProgress._reportProgress(sourceVersionHash, 0.1)
 				currentProcess = undefined
 
 				// Scan field order:
-				currentProcess = scanFieldOrder(sourceHandle, exp.endRequirement.version)
-				const resultFieldOrder = await currentProcess
+				let resultFieldOrder = FieldOrder.Unknown
+				if (hasVideoStream) {
+					currentProcess = scanFieldOrder(sourceHandle, exp.endRequirement.version)
+					resultFieldOrder = await currentProcess
+					currentProcess = undefined
+				}
 				workInProgress._reportProgress(sourceVersionHash, 0.2)
-				currentProcess = undefined
 
 				// Scan more info:
-				currentProcess = scanMoreInfo(sourceHandle, ffProbeScan, exp.endRequirement.version, (progress) => {
-					workInProgress._reportProgress(sourceVersionHash, 0.21 + 0.77 * progress)
-				})
-				const { blacks: resultBlacks, freezes: resultFreezes, scenes: resultScenes } = await currentProcess
+				let resultBlacks: ScanAnomaly[] = []
+				let resultFreezes: ScanAnomaly[] = []
+				let resultScenes: number[] = []
+				if (hasVideoStream) {
+					currentProcess = scanMoreInfo(sourceHandle, ffProbeScan, exp.endRequirement.version, (progress) => {
+						workInProgress._reportProgress(sourceVersionHash, 0.21 + 0.77 * progress)
+					})
+					const result = await currentProcess
+					resultBlacks = result.blacks
+					resultFreezes = result.freezes
+					resultScenes = result.scenes
+					currentProcess = undefined
+				}
 				workInProgress._reportProgress(sourceVersionHash, 0.99)
-				currentProcess = undefined
 
 				const deepScan: DeepScanResult = {
 					field_order: resultFieldOrder,


### PR DESCRIPTION
Currently, the deep scan process fails on audio-only files and throws an error. This PR prevents those errors from occurring.

In this PR, deep scanning audio-only files is effectively a no-op, but in the future there may be information we want to extract from audio files during this step.