### PR TITLE
fix: prevent active httpProxy file uploads from timing out

### DIFF
--- a/shared/packages/worker/src/worker/accessorHandlers/httpProxy.ts
+++ b/shared/packages/worker/src/worker/accessorHandlers/httpProxy.ts
@@ -123,6 +123,7 @@ export class HTTPProxyAccessorHandle<Metadata> extends GenericAccessorHandle<Met
 		const fetch = fetchWithController(this.fullUrl, {
 			method: 'POST',
 			body: formData, // sourceStream.readStream,
+			refreshStream: sourceStream,
 		})
 		const streamHandler: PutPackageHandler = new PutPackageHandler(() => {
 			fetch.controller.abort()

--- a/shared/packages/worker/src/worker/accessorHandlers/lib/fetch.ts
+++ b/shared/packages/worker/src/worker/accessorHandlers/lib/fetch.ts
@@ -2,6 +2,13 @@ import AbortController from 'abort-controller'
 import fetch, { Response, RequestInit } from 'node-fetch'
 import { INNER_ACTION_TIMEOUT } from '@shared/api'
 
+export type FetchWithControllerOptions = Omit<RequestInit, 'signal'> & {
+	/**
+	 * If provided, will refresh the fetch abort timeout every time the 'data' event is fired.
+	 */
+	refreshStream?: NodeJS.ReadableStream
+}
+
 /**
  * Fetches a url using node-fetch and times out prudently
  * Note that this function does not support using an AbortController (use fetchWithController for that)
@@ -16,17 +23,28 @@ export function fetchWithTimeout(url: string, options?: Omit<RequestInit, 'signa
  */
 export function fetchWithController(
 	url: string,
-	options?: Omit<RequestInit, 'signal'>
+	options?: FetchWithControllerOptions
 ): { response: Promise<Response>; controller: AbortController } {
 	const controller = new AbortController()
+
 	return {
 		response: new Promise((resolve, reject) => {
-			const timeout = setTimeout(() => {
-				reject(new Error(`Timeout when fetching "${url}"`))
+			const refreshTimeout = () => {
+				return setTimeout(() => {
+					reject(new Error(`Timeout when fetching "${url}"`))
 
-				// Don't leave the request hanging and possibly consume bandwidth:
-				controller.abort()
-			}, INNER_ACTION_TIMEOUT)
+					// Don't leave the request hanging and possibly consume bandwidth:
+					controller.abort()
+				}, INNER_ACTION_TIMEOUT)
+			}
+
+			let timeout = refreshTimeout()
+			if (options?.refreshStream) {
+				options.refreshStream.on('data', () => {
+					clearTimeout(timeout)
+					timeout = refreshTimeout()
+				})
+			}
 
 			fetch(url, { ...options, signal: controller.signal })
 				.then((response) => {


### PR DESCRIPTION
This PR introduces a `refreshStream` option to the `fetchWithController` options argument. It is of the type `NodeJS.ReadableStream | undefined`.

When a `refreshStream` is provided, `fetchWithController` will monitor the `data` event of the `refreshStream` and use that to refresh the fetch timeout. This ensures that active file uploads (such as preview generation of long media packages) won't get prematurely aborted by said timeout.